### PR TITLE
Added ability to set all other AssemblyInfo properties.

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/changeassemblyversion/ChangeAssemblyVersion.java
+++ b/src/main/java/org/jenkinsci/plugins/changeassemblyversion/ChangeAssemblyVersion.java
@@ -24,13 +24,38 @@ public class ChangeAssemblyVersion extends Builder {
     private final String assemblyFile;
     private final String regexPattern;
     private final String replacementPattern;
+    private final String assemblyTitle;
+    private final String assemblyDescription;
+    private final String assemblyCompany;
+    private final String assemblyProduct;
+    private final String assemblyCopyright;
+    private final String assemblyTrademark;
+    private final String assemblyCulture;
 
     @DataBoundConstructor
-    public ChangeAssemblyVersion(String versionPattern, String assemblyFile, String regexPattern, String replacementPattern) {
+    public ChangeAssemblyVersion(String versionPattern, 
+        String assemblyFile, 
+        String regexPattern, 
+        String replacementPattern, 
+        String assemblyTitle,
+        String assemblyDescription,
+        String assemblyCompany,
+        String assemblyProduct,
+        String assemblyCopyright,
+        String assemblyTrademark,
+        String assemblyCulture
+        ) {
         this.versionPattern = versionPattern;
         this.assemblyFile = assemblyFile;
         this.regexPattern = regexPattern;
         this.replacementPattern = replacementPattern;
+        this.assemblyTitle = assemblyTitle;
+        this.assemblyDescription = assemblyDescription;
+        this.assemblyCompany = assemblyCompany;
+        this.assemblyProduct = assemblyProduct;
+        this.assemblyCopyright = assemblyCopyright;
+        this.assemblyTrademark = assemblyTrademark;
+        this.assemblyCulture = assemblyCulture;
     }
 
     public String getVersionPattern() {
@@ -48,7 +73,35 @@ public class ChangeAssemblyVersion extends Builder {
     public String getReplacementPattern() {
         return this.replacementPattern;
     }
+    
+    public String getAssemblyTitle() {
+        return this.assemblyTitle;
+    }
+    
+    public String getAssemblyDescription() {
+        return this.assemblyDescription;
+    }
+    
+    public String getAssemblyCompany() {
+        return this.assemblyCompany;
+    }
+    
+    public String getAssemblyProduct() {
+        return this.assemblyProduct;
+    }            
 
+    public String getAssemblyCopyright() {
+        return this.assemblyCopyright;
+    }
+
+    public String getAssemblyTrademark() {
+        return this.assemblyTrademark;
+    }
+    
+    public String getAssemblyCulture() {
+        return this.assemblyCulture;
+    }
+    
     /**
      *
      * The perform method is gonna search all the file named "Assemblyinfo.cs"
@@ -76,10 +129,29 @@ public class ChangeAssemblyVersion extends Builder {
                 listener.getLogger().println("Please provide a valid version pattern.");
                 return false;
             }
-            listener.getLogger().println(String.format("Changing the file(s) %s to version : %s", assemblyGlob, version));
+            listener.getLogger().println(String.format("Changing File(s): %s", assemblyGlob));
+            listener.getLogger().println(String.format("Assembly Title : %s",  this.assemblyTitle));
+            listener.getLogger().println(String.format("Assembly Description : %s",  this.assemblyDescription));
+            listener.getLogger().println(String.format("Assembly Company : %s",  this.assemblyCompany));
+            listener.getLogger().println(String.format("Assembly Product : %s",  this.assemblyProduct));
+            listener.getLogger().println(String.format("Assembly Copyright : %s",  this.assemblyCopyright));
+            listener.getLogger().println(String.format("Assembly Trademark : %s",  this.assemblyTrademark));
+            listener.getLogger().println(String.format("Assembly Culture : %s",  this.assemblyCulture));
+            
             for (FilePath f : build.getWorkspace().list(assemblyGlob))
             {
-                new ChangeTools(f, this.regexPattern, this.replacementPattern).Replace(version, listener);                
+                // Update the AssemblyVerion and AssemblyFileVersion
+                new ChangeTools(f, this.regexPattern, this.replacementPattern).Replace(version, listener);
+                
+                // Set new things, empty string being ok for them.
+                // TODO: Would we need a regex for these or just blast as we are doing now?
+                new ChangeTools(f, "AssemblyTitle[(]\".*\"[)]", "AssemblyTitle(\"%s\")").Replace(this.assemblyTitle, listener);            
+                new ChangeTools(f, "AssemblyDescription[(]\".*\"[)]", "AssemblyDescription(\"%s\")").Replace(this.assemblyDescription, listener);
+                new ChangeTools(f, "AssemblyCompany[(]\".*\"[)]", "AssemblyCompany(\"%s\")").Replace(this.assemblyCompany, listener);
+                new ChangeTools(f, "AssemblyProduct[(]\".*\"[)]", "AssemblyProduct(\"%s\")").Replace(this.assemblyProduct, listener);
+                new ChangeTools(f, "AssemblyCopyright[(]\".*\"[)]", "AssemblyCopyright(\"%s\")").Replace(this.assemblyCopyright, listener);
+                new ChangeTools(f, "AssemblyTrademark[(]\".*\"[)]", "AssemblyTrademark(\"%s\")").Replace(this.assemblyTrademark, listener);
+                new ChangeTools(f, "AssemblyCulture[(]\".*\"[)]", "AssemblyCulture(\"%s\")").Replace(this.assemblyCulture, listener);
             }
         } catch (Exception ex) {
             StringWriter sw = new StringWriter();

--- a/src/main/java/org/jenkinsci/plugins/changeassemblyversion/ChangeAssemblyVersion.java
+++ b/src/main/java/org/jenkinsci/plugins/changeassemblyversion/ChangeAssemblyVersion.java
@@ -129,14 +129,27 @@ public class ChangeAssemblyVersion extends Builder {
                 listener.getLogger().println("Please provide a valid version pattern.");
                 return false;
             }
+            
+            // Expand env variables
+            String assemblyTitle = envVars.expand(this.assemblyTitle);
+            String assemblyDescription = envVars.expand(this.assemblyDescription);
+            String assemblyCompany = envVars.expand(this.assemblyCompany);
+            String assemblyProduct = envVars.expand(this.assemblyProduct);
+            String assemblyCopyright = envVars.expand(this.assemblyCopyright);
+            String assemblyTrademark = envVars.expand(this.assemblyTrademark);
+            String assemblyCulture = envVars.expand(this.assemblyCulture);
+            
+            
+            // Log new expanded values
             listener.getLogger().println(String.format("Changing File(s): %s", assemblyGlob));
-            listener.getLogger().println(String.format("Assembly Title : %s",  this.assemblyTitle));
-            listener.getLogger().println(String.format("Assembly Description : %s",  this.assemblyDescription));
-            listener.getLogger().println(String.format("Assembly Company : %s",  this.assemblyCompany));
-            listener.getLogger().println(String.format("Assembly Product : %s",  this.assemblyProduct));
-            listener.getLogger().println(String.format("Assembly Copyright : %s",  this.assemblyCopyright));
-            listener.getLogger().println(String.format("Assembly Trademark : %s",  this.assemblyTrademark));
-            listener.getLogger().println(String.format("Assembly Culture : %s",  this.assemblyCulture));
+            listener.getLogger().println(String.format("Assembly Version : %s",  version));
+            listener.getLogger().println(String.format("Assembly Title : %s",  assemblyTitle));
+            listener.getLogger().println(String.format("Assembly Description : %s",  assemblyDescription));
+            listener.getLogger().println(String.format("Assembly Company : %s",  assemblyCompany));
+            listener.getLogger().println(String.format("Assembly Product : %s",  assemblyProduct));
+            listener.getLogger().println(String.format("Assembly Copyright : %s",  assemblyCopyright));
+            listener.getLogger().println(String.format("Assembly Trademark : %s",  assemblyTrademark));
+            listener.getLogger().println(String.format("Assembly Culture : %s",  assemblyCulture));
             
             for (FilePath f : build.getWorkspace().list(assemblyGlob))
             {
@@ -145,13 +158,13 @@ public class ChangeAssemblyVersion extends Builder {
                 
                 // Set new things, empty string being ok for them.
                 // TODO: Would we need a regex for these or just blast as we are doing now?
-                new ChangeTools(f, "AssemblyTitle[(]\".*\"[)]", "AssemblyTitle(\"%s\")").Replace(this.assemblyTitle, listener);            
-                new ChangeTools(f, "AssemblyDescription[(]\".*\"[)]", "AssemblyDescription(\"%s\")").Replace(this.assemblyDescription, listener);
-                new ChangeTools(f, "AssemblyCompany[(]\".*\"[)]", "AssemblyCompany(\"%s\")").Replace(this.assemblyCompany, listener);
-                new ChangeTools(f, "AssemblyProduct[(]\".*\"[)]", "AssemblyProduct(\"%s\")").Replace(this.assemblyProduct, listener);
-                new ChangeTools(f, "AssemblyCopyright[(]\".*\"[)]", "AssemblyCopyright(\"%s\")").Replace(this.assemblyCopyright, listener);
-                new ChangeTools(f, "AssemblyTrademark[(]\".*\"[)]", "AssemblyTrademark(\"%s\")").Replace(this.assemblyTrademark, listener);
-                new ChangeTools(f, "AssemblyCulture[(]\".*\"[)]", "AssemblyCulture(\"%s\")").Replace(this.assemblyCulture, listener);
+                new ChangeTools(f, "AssemblyTitle[(]\".*\"[)]", "AssemblyTitle(\"%s\")").Replace(assemblyTitle, listener);            
+                new ChangeTools(f, "AssemblyDescription[(]\".*\"[)]", "AssemblyDescription(\"%s\")").Replace(assemblyDescription, listener);
+                new ChangeTools(f, "AssemblyCompany[(]\".*\"[)]", "AssemblyCompany(\"%s\")").Replace(assemblyCompany, listener);
+                new ChangeTools(f, "AssemblyProduct[(]\".*\"[)]", "AssemblyProduct(\"%s\")").Replace(assemblyProduct, listener);
+                new ChangeTools(f, "AssemblyCopyright[(]\".*\"[)]", "AssemblyCopyright(\"%s\")").Replace(assemblyCopyright, listener);
+                new ChangeTools(f, "AssemblyTrademark[(]\".*\"[)]", "AssemblyTrademark(\"%s\")").Replace(assemblyTrademark, listener);
+                new ChangeTools(f, "AssemblyCulture[(]\".*\"[)]", "AssemblyCulture(\"%s\")").Replace(assemblyCulture, listener);
             }
         } catch (Exception ex) {
             StringWriter sw = new StringWriter();

--- a/src/main/java/org/jenkinsci/plugins/changeassemblyversion/ChangeTools.java
+++ b/src/main/java/org/jenkinsci/plugins/changeassemblyversion/ChangeTools.java
@@ -26,11 +26,11 @@ public class ChangeTools {
         }
     }
 
-    public void Replace(String version, BuildListener listener) throws IOException, InterruptedException {
+    public void Replace(String replacement, BuildListener listener) throws IOException, InterruptedException {
         String content = file.readToString();
-        listener.getLogger().println(String.format("Updating file : %s, Version : %s", file.getRemote(), version));
-        content = content.replaceAll(regexPattern, String.format(replacementPattern, version));
-        listener.getLogger().println(String.format("Updating file : %s", file.getRemote()));
+        listener.getLogger().println(String.format("Updating file : %s, Replacement : %s", file.getRemote(), replacement));
+        content = content.replaceAll(regexPattern, String.format(replacementPattern, replacement));
+        //listener.getLogger().println(String.format("Updating file : %s", file.getRemote()));
         file.write(content, null);
     }
 }

--- a/src/main/java/org/jenkinsci/plugins/changeassemblyversion/ChangeTools.java
+++ b/src/main/java/org/jenkinsci/plugins/changeassemblyversion/ChangeTools.java
@@ -27,10 +27,17 @@ public class ChangeTools {
     }
 
     public void Replace(String replacement, BuildListener listener) throws IOException, InterruptedException {
-        String content = file.readToString();
-        listener.getLogger().println(String.format("Updating file : %s, Replacement : %s", file.getRemote(), replacement));
-        content = content.replaceAll(regexPattern, String.format(replacementPattern, replacement));
-        //listener.getLogger().println(String.format("Updating file : %s", file.getRemote()));
-        file.write(content, null);
+        if (replacement != null && !replacement.isEmpty())
+        {
+            String content = file.readToString();       
+            listener.getLogger().println(String.format("Updating file : %s, Replacement : %s", file.getRemote(), replacement));
+            content = content.replaceAll(regexPattern, String.format(replacementPattern, replacement));
+            //listener.getLogger().println(String.format("Updating file : %s", file.getRemote()));
+            file.write(content, null);
+        }
+        else
+        {
+            listener.getLogger().println(String.format("Skipping replacement because value is empty."));
+        }
     }
 }

--- a/src/main/resources/org/jenkinsci/plugins/changeassemblyversion/ChangeAssemblyVersion/config.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/changeassemblyversion/ChangeAssemblyVersion/config.jelly
@@ -2,6 +2,27 @@
 	<f:entry title="${%Assembly Version}" field="versionPattern">
         <f:textbox/>
 	</f:entry>
+	<f:entry title="${%Assembly Title}" field="assemblyTitle">
+        <f:textbox/>
+	</f:entry>
+	<f:entry title="${%Assembly Description}" field="assemblyDescription">
+        <f:textbox/>
+	</f:entry>
+	<f:entry title="${%Assembly Company}" field="assemblyCompany">
+        <f:textbox/>
+	</f:entry>
+	<f:entry title="${%Assembly Product}" field="assemblyProduct">
+        <f:textbox/>
+	</f:entry>
+	<f:entry title="${%Assembly Copyright}" field="assemblyCopyright">
+        <f:textbox/>
+	</f:entry>
+	<f:entry title="${%Assembly Trademark}" field="assemblyTrademark">
+        <f:textbox/>
+	</f:entry>
+	<f:entry title="${%Assembly Culture}" field="assemblyCulture">
+        <f:textbox/>
+	</f:entry>	
 	<f:entry title="${%FileName}" field="assemblyFile">
 		<f:textbox/>
 	</f:entry>

--- a/src/test/java/org/jenkinsci/plugins/changeassemblyversion/ReplacementsTest.java
+++ b/src/test/java/org/jenkinsci/plugins/changeassemblyversion/ReplacementsTest.java
@@ -61,17 +61,34 @@ public class ReplacementsTest {
                     BuildListener listener) throws InterruptedException, IOException {
                 build.getWorkspace().child("AssemblyVersion.cs").write("using System.Reflection;\n" +
 "\n" +
+"[assembly: AssemblyTitle(\"\")]\n" +
+"[assembly: AssemblyDescription(\"\")]\n" +
+"[assembly: AssemblyCompany(\"\")]\n" +
+"[assembly: AssemblyProduct(\"\")]\n" +
+"[assembly: AssemblyCopyright(\"\")]\n" +
+"[assembly: AssemblyTrademark(\"\")]\n" +
+"[assembly: AssemblyCulture(\"\")]\n" +
 "[assembly: AssemblyVersion(\"13.1.1.976\")]", "UTF-8");
                 return true;
             }
         });
-        ChangeAssemblyVersion builder = new ChangeAssemblyVersion("$PREFIX.${BUILD_NUMBER}", "AssemblyVersion.cs", "", "");
+        ChangeAssemblyVersion builder = new ChangeAssemblyVersion("$PREFIX.${BUILD_NUMBER}", "AssemblyVersion.cs", "", "", "MyTitle", "MyDescription", "MyCompany", "MyProduct", "MyCopyright", "MyTrademark", "MyCulture");
         project.getBuildersList().add(builder);
         FreeStyleBuild build = project.scheduleBuild2(0).get();
 
         //String s = FileUtils.readFileToString(build.getLogFile());
         String content = build.getWorkspace().child("AssemblyVersion.cs").readToString();
         assertTrue(content.contains("AssemblyVersion(\"1.1.0."));
+        
+        // Check that we update additional assembly info
+        assertTrue(content.contains("AssemblyTitle(\"MyTitle"));
+        assertTrue(content.contains("AssemblyDescription(\"MyDescription"));
+        assertTrue(content.contains("AssemblyCompany(\"MyCompany"));
+        assertTrue(content.contains("AssemblyProduct(\"MyProduct"));
+        assertTrue(content.contains("AssemblyCopyright(\"MyCopyright"));
+        assertTrue(content.contains("AssemblyTrademark(\"MyTrademark"));
+        assertTrue(content.contains("AssemblyCulture(\"MyCulture"));
+        
         assertTrue(builder.getVersionPattern().equals("$PREFIX.${BUILD_NUMBER}"));
     }
     
@@ -96,7 +113,7 @@ public class ReplacementsTest {
                 return true;
             }
         });
-        ChangeAssemblyVersion builder = new ChangeAssemblyVersion("$PREFIX.${BUILD_NUMBER}", "", "", "");
+        ChangeAssemblyVersion builder = new ChangeAssemblyVersion("$PREFIX.${BUILD_NUMBER}", "", "", "", "", "", "", "", "", "", "");
         project.getBuildersList().add(builder);
         FreeStyleBuild build = project.scheduleBuild2(0).get();
 


### PR DESCRIPTION
Hi! I've been using this plugin for a long time, but just recently wanted to have it modify other things like AssemblyCompany, Copyright, etc. I made some modifications to the system to ask for those values as well, and only overwrite them in the assemblyinfo.cs file if they are provided (empty string will not overwrite whatever is in assemblyinfo.cs). This is working great for us. I'll continue to refine my fork or you are welcome to take these changes if you'd like!

This is my first time actually using github so bear with me if I did anything wrong!

here is what the UI looks like:
![image](https://cloud.githubusercontent.com/assets/11036865/8241616/4aaf6cec-15bf-11e5-8a00-c0527e9474f1.png)
