### PR TITLE
Update ChangeTools.java

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/changeassemblyversion/ChangeTools.java
+++ b/src/main/java/org/jenkinsci/plugins/changeassemblyversion/ChangeTools.java
@@ -29,7 +29,7 @@ public class ChangeTools {
     public void Replace(String replacement, BuildListener listener) throws IOException, InterruptedException {
         if (replacement != null && !replacement.isEmpty())
         {
-            String content = file.readToString();       
+            String content = file.readToString();  // needs to use read() instead!
             listener.getLogger().println(String.format("Updating file : %s, Replacement : %s", file.getRemote(), replacement));
             content = content.replaceAll(regexPattern, String.format(replacementPattern, replacement));
             //listener.getLogger().println(String.format("Updating file : %s", file.getRemote()));


### PR DESCRIPTION
Hi folks. I'm new to submitting issues without providing a proper patch here at github. Here's my observation anyways:

This reads content of file in platform's default encoding. In my case, all AssemblyInfo.{vb|cs} templates are written as UTF-8 (with BOM header) which immediately breaks. Instead, file-encoding needs to be a plugin parameter and reading needs to be done from InputStream (via encoding), due to shitty hudson API. (Oddly enough, FilePath.write(...) already can take an encoding parameter. Yay for symmetric APIs.)