### PR TITLE
[FIXED JENKINS-37901] Make Assembly Version optional

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/changeassemblyversion/ChangeAssemblyVersion.java
+++ b/src/main/java/org/jenkinsci/plugins/changeassemblyversion/ChangeAssemblyVersion.java
@@ -123,11 +123,9 @@ public class ChangeAssemblyVersion extends Builder {
             String assemblyGlob = this.assemblyFile == null || this.assemblyFile.equals("") ? "**/AssemblyInfo.cs" : this.assemblyFile;
 
             EnvVars envVars = build.getEnvironment(listener);
-            String version = new AssemblyVersion(this.versionPattern, envVars).getVersion();
-            if (versionPattern == null || StringUtils.isEmpty(versionPattern))
-            {
-                listener.getLogger().println("Please provide a valid version pattern.");
-                return false;
+            String version = "";
+            if (versionPattern != null && !StringUtils.isEmpty(versionPattern)) {
+                version = new AssemblyVersion(this.versionPattern, envVars).getVersion();
             }
             
             // Expand env variables


### PR DESCRIPTION
It should be possible to change some assembly meta-data other than
version numbers, e.g. Company or Copyright, without actually touching
the version numbers in files. This patch makes the plugin not to
abort if the version number is not given.

Signed-off-by: Tuomas Jormola tj@solitudo.net
