### PR TITLE
Fix bug https://issues.jenkins-ci.org/browse/JENKINS-36375

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -27,7 +27,7 @@
 	</developers>
 	<groupId>org.jenkinsci.plugins</groupId>
 	<artifactId>change-assembly-version-plugin</artifactId>
-	<version>1.11-SNAPSHOT</version>
+	<version>1.12</version>
 	<packaging>hpi</packaging>
 
 	<licenses>

--- a/pom.xml
+++ b/pom.xml
@@ -27,7 +27,7 @@
 	</developers>
 	<groupId>org.jenkinsci.plugins</groupId>
 	<artifactId>change-assembly-version-plugin</artifactId>
-	<version>1.12</version>
+	<version>1.11-SNAPSHOT</version>
 	<packaging>hpi</packaging>
 
 	<licenses>

--- a/src/main/java/org/jenkinsci/plugins/changeassemblyversion/ChangeTools.java
+++ b/src/main/java/org/jenkinsci/plugins/changeassemblyversion/ChangeTools.java
@@ -8,7 +8,8 @@ import org.apache.commons.io.ByteOrderMark;
 import org.apache.commons.io.IOUtils;
 import org.apache.commons.io.input.BOMInputStream;
 
-import java.io.*;
+import java.io.IOException;
+import java.io.OutputStream;
 import java.nio.charset.Charset;
 
 public class ChangeTools {

--- a/src/main/java/org/jenkinsci/plugins/changeassemblyversion/ChangeTools.java
+++ b/src/main/java/org/jenkinsci/plugins/changeassemblyversion/ChangeTools.java
@@ -37,15 +37,20 @@ public class ChangeTools {
         if (replacement != null && !replacement.isEmpty())
         {
             BOMInputStream inputStream = new BOMInputStream(file.read());
-            ByteOrderMark bom = inputStream.getBOM();
-
+            String content;
+            ByteOrderMark bom;
             Charset fileEncoding = Charset.defaultCharset();
-            if (bom != null) {
-                fileEncoding = Charset.forName(bom.getCharsetName());
-            }
+            try {
+                bom = inputStream.getBOM();
+                if (bom != null) {
+                    fileEncoding = Charset.forName(bom.getCharsetName());
+                }
 
-            String content = IOUtils.toString(inputStream, fileEncoding);
-            inputStream.close();
+                content = IOUtils.toString(inputStream, fileEncoding);
+            }
+            finally {
+                inputStream.close();
+            }
             listener.getLogger().println(String.format("Updating file : %s, Replacement : %s", file.getRemote(), replacement));
             content = content.replaceAll(regexPattern, String.format(replacementPattern, replacement));
             //listener.getLogger().println(String.format("Updating file : %s", file.getRemote()));

--- a/src/main/java/org/jenkinsci/plugins/changeassemblyversion/ChangeTools.java
+++ b/src/main/java/org/jenkinsci/plugins/changeassemblyversion/ChangeTools.java
@@ -56,8 +56,7 @@ public class ChangeTools {
             //listener.getLogger().println(String.format("Updating file : %s", file.getRemote()));
             OutputStream os = file.write();
             try {
-                if (inputStream.hasBOM())
-                {
+                if (inputStream.hasBOM()){
                     os.write(inputStream.getBOM().getBytes());
                 }
                 os.write(content.getBytes(fileEncoding));

--- a/src/main/java/org/jenkinsci/plugins/changeassemblyversion/ChangeTools.java
+++ b/src/main/java/org/jenkinsci/plugins/changeassemblyversion/ChangeTools.java
@@ -1,11 +1,14 @@
 package org.jenkinsci.plugins.changeassemblyversion;
 
+import com.sun.media.jfxmedia.track.Track;
 import hudson.FilePath;
 import hudson.model.BuildListener;
 import hudson.model.TaskListener;
+import org.apache.commons.io.ByteOrderMark;
+import org.apache.commons.io.input.BOMInputStream;
 
-import java.io.OutputStream;
-import java.io.IOException;
+import java.io.*;
+import java.nio.charset.Charset;
 
 public class ChangeTools {
 
@@ -31,13 +34,33 @@ public class ChangeTools {
     public void Replace(String replacement, TaskListener listener) throws IOException, InterruptedException {
         if (replacement != null && !replacement.isEmpty())
         {
-            String content = file.readToString();  // needs to use read() instead!
+            BOMInputStream inputStream = new BOMInputStream(file.read());
+            ByteOrderMark bom = inputStream.getBOM();
+
+            Charset fileEncoding = Charset.defaultCharset();
+            if(inputStream.hasBOM()) {
+                fileEncoding = Charset.forName(inputStream.getBOM().getCharsetName());
+            }
+            byte[] buffer = new byte[8192];
+            ByteArrayOutputStream bs = new ByteArrayOutputStream();
+            BufferedOutputStream out = new BufferedOutputStream(bs);
+            int read = inputStream.read(buffer, 0, buffer.length);
+            while (read > 0){
+                out.write(buffer, 0, read);
+                read = inputStream.read(buffer, 0, buffer.length);
+            }
+            out.flush();
+            String content = new String(bs.toByteArray(), fileEncoding);
             listener.getLogger().println(String.format("Updating file : %s, Replacement : %s", file.getRemote(), replacement));
             content = content.replaceAll(regexPattern, String.format(replacementPattern, replacement));
             //listener.getLogger().println(String.format("Updating file : %s", file.getRemote()));
             OutputStream os = file.write();
             try {
-                os.write(content.getBytes());
+                if (inputStream.hasBOM())
+                {
+                    os.write(inputStream.getBOM().getBytes());
+                }
+                os.write(content.getBytes(fileEncoding));
             } finally {
                 os.close();
             }

--- a/src/test/java/org/jenkinsci/plugins/changeassemblyversion/ReplacementsTest.java
+++ b/src/test/java/org/jenkinsci/plugins/changeassemblyversion/ReplacementsTest.java
@@ -32,7 +32,10 @@ import hudson.model.FreeStyleBuild;
 import hudson.model.FreeStyleProject;
 import hudson.slaves.EnvironmentVariablesNodeProperty;
 
-import java.io.*;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.io.OutputStreamWriter;
 import java.util.concurrent.ExecutionException;
 
 import org.apache.commons.io.ByteOrderMark;

--- a/src/test/java/org/jenkinsci/plugins/changeassemblyversion/ReplacementsTest.java
+++ b/src/test/java/org/jenkinsci/plugins/changeassemblyversion/ReplacementsTest.java
@@ -23,6 +23,7 @@
  */
 package org.jenkinsci.plugins.changeassemblyversion;
 
+import com.google.common.primitives.Bytes;
 import hudson.EnvVars;
 import hudson.Launcher;
 import hudson.model.AbstractBuild;
@@ -30,10 +31,20 @@ import hudson.model.BuildListener;
 import hudson.model.FreeStyleBuild;
 import hudson.model.FreeStyleProject;
 import hudson.slaves.EnvironmentVariablesNodeProperty;
-import java.io.IOException;
+
+import java.io.*;
+import java.util.concurrent.ExecutionException;
+
+import org.apache.commons.io.ByteOrderMark;
 import org.apache.commons.io.FileUtils;
+
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
+
+import org.apache.commons.io.IOUtils;
+import org.apache.commons.io.input.BOMInputStream;
+import org.bouncycastle.util.Arrays;
 import org.junit.Rule;
 import org.junit.Test;
 import org.jvnet.hudson.test.JenkinsRule;
@@ -123,5 +134,147 @@ public class ReplacementsTest {
         content = build.getWorkspace().child(f2).readToString();
         assertTrue(content.contains("AssemblyVersion(\"13.1.1.976"));
         assertTrue(builder.getVersionPattern().equals("$PREFIX.${BUILD_NUMBER}"));
+    }
+
+    @Test
+    public void testBOMFileReplace() throws IOException, ExecutionException, InterruptedException {
+        FreeStyleProject project = j.createFreeStyleProject();
+        final ByteOrderMark fileBom = ByteOrderMark.UTF_8;
+        project.getBuildersList().add(new TestBuilder() {
+            public boolean perform(AbstractBuild<?, ?> build, Launcher launcher,
+                                   BuildListener listener) throws InterruptedException, IOException {
+                OutputStream outputStream = build.getWorkspace().child("AssemblyVersion.cs").write();
+                outputStream.write(fileBom.getBytes());
+                OutputStreamWriter w = new OutputStreamWriter(outputStream, "UTF-8");
+                try{
+                    w.write("using System.Reflection;\n" +
+                            "\n" +
+                            "[assembly: AssemblyTitle(\"\")]\n" +
+                            "[assembly: AssemblyDescription(\"\")]\n" +
+                            "[assembly: AssemblyCompany(\"\")]\n" +
+                            "[assembly: AssemblyProduct(\"\")]\n" +
+                            "[assembly: AssemblyCopyright(\"\")]\n" +
+                            "[assembly: AssemblyTrademark(\"\")]\n" +
+                            "[assembly: AssemblyCulture(\"\")]\n" +
+                            "[assembly: AssemblyVersion(\"13.1.1.976\")]");
+                }
+                finally {
+                    w.close();
+                    outputStream.close();
+                }
+
+                return true;
+            }
+        });
+        ChangeAssemblyVersion builder = new ChangeAssemblyVersion("1.2.3", "AssemblyVersion.cs", "", "", "MyTitle", "MyDescription", "MyCompany", "MyProduct", "MyCopyright", "MyTrademark", "MyCulture");
+        project.getBuildersList().add(builder);
+        FreeStyleBuild build = project.scheduleBuild2(0).get();
+
+        //String s = FileUtils.readFileToString(build.getLogFile());
+        InputStream readStream = build.getWorkspace().child("AssemblyVersion.cs").read();
+        BOMInputStream bomInputStream = new BOMInputStream(readStream);
+        ByteOrderMark bomAfterChange = bomInputStream.getBOM();
+        String content = org.apache.commons.io.IOUtils.toString(bomInputStream);
+        bomInputStream.close();
+        readStream.close();
+
+        // the replaced file should have the same BOM as the origin.
+        assertEquals(bomAfterChange.getCharsetName(), fileBom.getCharsetName());
+        // the first bytes should be readable characters.
+        assertTrue(content.matches("(?s)^using.*"));
+        // Check that we update additional assembly info
+        assertTrue(content.contains("AssemblyTitle(\"MyTitle"));
+        assertTrue(content.contains("AssemblyDescription(\"MyDescription"));
+        assertTrue(content.contains("AssemblyCompany(\"MyCompany"));
+        assertTrue(content.contains("AssemblyProduct(\"MyProduct"));
+        assertTrue(content.contains("AssemblyCopyright(\"MyCopyright"));
+        assertTrue(content.contains("AssemblyTrademark(\"MyTrademark"));
+        assertTrue(content.contains("AssemblyCulture(\"MyCulture"));
+    }
+
+    @Test
+    public void testBOMFileNotModified() throws IOException, ExecutionException, InterruptedException {
+        FreeStyleProject project = j.createFreeStyleProject();
+        final byte[] originFileBinary = ("using System.Reflection;\n" +
+                "\n" +
+                "[assembly: AssemblyTitle(\"\")]\n" +
+                "[assembly: AssemblyDescription(\"\")]\n" +
+                "[assembly: AssemblyCompany(\"\")]\n" +
+                "[assembly: AssemblyProduct(\"\")]\n" +
+                "[assembly: AssemblyCopyright(\"\")]\n" +
+                "[assembly: AssemblyTrademark(\"\")]\n" +
+                "[assembly: AssemblyCulture(\"\")]\n" +
+                "[assembly: AssemblyVersion(\"13.1.1.976\")]").getBytes();
+        project.getBuildersList().add(new TestBuilder() {
+            public boolean perform(AbstractBuild<?, ?> build, Launcher launcher,
+                                   BuildListener listener) throws InterruptedException, IOException {
+                OutputStream outputStream = build.getWorkspace().child("AssemblyVersion.cs").write();
+                try{
+                    outputStream.write(originFileBinary);
+                }
+                finally {
+                    outputStream.close();
+                }
+
+                return true;
+            }
+        });
+
+        ChangeAssemblyVersion builder = new ChangeAssemblyVersion("");
+        project.getBuildersList().add(builder);
+        FreeStyleBuild build = project.scheduleBuild2(0).get();
+
+        //String s = FileUtils.readFileToString(build.getLogFile());
+        InputStream readStream = build.getWorkspace().child("AssemblyVersion.cs").read();
+
+        byte[] binaryAfterChange = IOUtils.toByteArray(readStream);
+        String content = new String(binaryAfterChange, "UTF-8");
+
+        // the replaced file should have the same BOM as the origin.
+        assertTrue(Arrays.areEqual(originFileBinary, binaryAfterChange));
+    }
+
+    @Test
+    public void testBOMFileNotModified2() throws IOException, ExecutionException, InterruptedException {
+        FreeStyleProject project = j.createFreeStyleProject();
+        ByteOrderMark bom = ByteOrderMark.UTF_8;
+        byte[] bomBinary = bom.getBytes();
+        final byte[] originFileContentBinary = ("using System.Reflection;\n" +
+                "\n" +
+                "[assembly: AssemblyTitle(\"\")]\n" +
+                "[assembly: AssemblyDescription(\"\")]\n" +
+                "[assembly: AssemblyCompany(\"\")]\n" +
+                "[assembly: AssemblyProduct(\"\")]\n" +
+                "[assembly: AssemblyCopyright(\"\")]\n" +
+                "[assembly: AssemblyTrademark(\"\")]\n" +
+                "[assembly: AssemblyCulture(\"\")]\n" +
+                "[assembly: AssemblyVersion(\"13.1.1.976\")]").getBytes();
+        final byte[] originFileBinary = Bytes.concat(bomBinary, originFileContentBinary);
+        project.getBuildersList().add(new TestBuilder() {
+            public boolean perform(AbstractBuild<?, ?> build, Launcher launcher,
+                                   BuildListener listener) throws InterruptedException, IOException {
+                OutputStream outputStream = build.getWorkspace().child("AssemblyVersion.cs").write();
+                try{
+                    outputStream.write(originFileBinary);
+                }
+                finally {
+                    outputStream.close();
+                }
+
+                return true;
+            }
+        });
+
+        ChangeAssemblyVersion builder = new ChangeAssemblyVersion("");
+        project.getBuildersList().add(builder);
+        FreeStyleBuild build = project.scheduleBuild2(0).get();
+
+        //String s = FileUtils.readFileToString(build.getLogFile());
+        InputStream readStream = build.getWorkspace().child("AssemblyVersion.cs").read();
+        byte[] binaryAfterChange = IOUtils.toByteArray(readStream);
+        readStream.close();
+
+        // the replaced file should have the same BOM as the origin.
+        assertTrue(Arrays.areEqual(originFileBinary, binaryAfterChange));
     }
 }


### PR DESCRIPTION
support BOM encoding of AssemblyInfo.cs file.

Read the original file BOM, and if it exists, add BOM when writing back. This can void the file encoding/decoding issue when file is not encoded as the default charset of platform.