### PR TITLE
Remove unused JavaFX import

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/changeassemblyversion/ChangeTools.java
+++ b/src/main/java/org/jenkinsci/plugins/changeassemblyversion/ChangeTools.java
@@ -1,6 +1,5 @@
 package org.jenkinsci.plugins.changeassemblyversion;
 
-import com.sun.media.jfxmedia.track.Track;
 import hudson.FilePath;
 import hudson.model.BuildListener;
 import hudson.model.TaskListener;


### PR DESCRIPTION
**Untested.** In Java 11, JavaFX was removed from the SDK. It is now in its own separate module, and if you want to use it in your application you will need to specifically include it. Since this import is unused, might as well stop importing it.